### PR TITLE
Change strategy for termination of resource limiting threads

### DIFF
--- a/src/server/contest/sandbox/resource_limits.h
+++ b/src/server/contest/sandbox/resource_limits.h
@@ -4,7 +4,7 @@
 #include <sys/types.h>
 
 // For 'exceeded'
-#define FATAL_ERROR_EXCEED -1
+#define FATAL_ERROR_EXCEED 4
 #define NO_EXCEED 0
 #define MEM_LIM_EXCEED 1
 #define TIME_LIM_EXCEED 2
@@ -33,10 +33,9 @@ typedef struct CgroupLocs {
   // Directory paths should not have trailing forward slash
 } CgroupLocs;
 
-typedef struct TerminatePayload TerminatePayload;
-
 int setResourceLimits(
   pid_t pid, const ResLimits *res_limits, const CgroupLocs *cg_locs,
-  int *exceeded, TerminatePayload **pl);
+  int *exceeded, pthread_mutex_t *terminate_child,
+  pthread_t *watcher_threads, int num_watcher_threads);
 
 #endif

--- a/src/server/contest/sandbox/sandbox.h
+++ b/src/server/contest/sandbox/sandbox.h
@@ -22,6 +22,3 @@ int sandboxExec(
   const char *whitelist, uid_t uid, gid_t gid);
 
 #endif
-/*
-  sudo ./a.out "1M" "1000000000" "1" "/sys/fs/cgroup/memory/test" "/sys/fs/cgroup/cpuacct/test" "/sys/fs/cgroup/pids/test" "temp/jail" "exect" "temp/in" "temp/out" "temp/wl" "1000" "1000"
-*/

--- a/src/server/contest/sandbox/syscall_manager.c
+++ b/src/server/contest/sandbox/syscall_manager.c
@@ -22,7 +22,7 @@ int installSysCallBlocker(scmp_filter_ctx *ctx, int whitelist_fd) {
 
   FILE *fp = fdopen(whitelist_fd, "r");
   if (fp == NULL) {
-    printErr("fopen failed: errno: %d", errno);
+    printErr("fdopen failed: errno: %d", errno);
     return -1;
   }
 

--- a/src/server/contest/sandbox/terminate.c
+++ b/src/server/contest/sandbox/terminate.c
@@ -8,13 +8,22 @@
 #include <signal.h>
 #include <errno.h>
 #include <sys/types.h>
+#include <fcntl.h>
 
 #include "terminate.h"
 #include "resource_limits.h"
 #include "logger.h"
 
-static char *getPidDir(const char *cg, pid_t pid) {
+#define MAX_STAT_READ_SIZE 50 // in bytes
 
+// -------------------- Helper Functions - Begin ---------------------------
+/*
+  Returns a pointer to an NTCS |cg|/|pid|.
+
+  Resource residue:
+    1 char malloc - 'pid_dir'
+*/
+char *getPidDir(const char *cg, pid_t pid) {
   char *pid_dir = malloc(
     sizeof(char) * (strlen(cg) + (int)ceil(log10(pid)) + 2));
   sprintf(pid_dir, "%s/%d", cg, pid);
@@ -22,67 +31,129 @@ static char *getPidDir(const char *cg, pid_t pid) {
 }
 
 int removePidDirs(const CgroupLocs *cg_locs, pid_t pid) {
-  char *memory_cg = getPidDir(cg_locs -> memory, pid);
-  char *cpuacct_cg = getPidDir(cg_locs -> cpuacct, pid);
-  char *pids_cg = getPidDir(cg_locs -> pids, pid);
+  char *memory_pid_dir = getPidDir(cg_locs -> memory, pid);
+  char *cpuacct_pid_dir = getPidDir(cg_locs -> cpuacct, pid);
+  char *pids_pid_dir = getPidDir(cg_locs -> pids, pid);
 
   int ret = 0;
-  if (rmdir(memory_cg) == -1) {
+  if (rmdir(memory_pid_dir) == -1) {
     printErr("rmdir failed: errno: %d", errno);
     ret = -1;
   }
-  if (rmdir(cpuacct_cg) == -1) {
+  if (rmdir(cpuacct_pid_dir) == -1) {
     printErr("rmdir failed: errno: %d", errno);
     ret = -1;
   }
-  if (rmdir(pids_cg) == -1) {
+  if (rmdir(pids_pid_dir) == -1) {
     printErr("rmdir failed: errno: %d", errno);
     ret = -1;
   }
 
-  free(memory_cg);
-  free(cpuacct_cg);
-  free(pids_cg);
+  free(memory_pid_dir);
+  free(cpuacct_pid_dir);
+  free(pids_pid_dir);
   return ret;
 }
 
-int terminate(TerminatePayload *tp) {
-  // Just for safety so that the function doesn't get called twice
-  if (tp -> once == 1) {
-    return 0;
+static char *readFile(const char *dir, const char *file) {
+
+  char *path = malloc(sizeof(char) * (strlen(dir) + strlen(file) + 2));
+  sprintf(path, "%s/%s", dir, file);
+
+  int fd = open(path, O_RDONLY);
+  free(path);
+  if (fd == -1) {
+    printErr("open failed: errno: %d", errno);
+    return NULL;
   }
-  tp -> once = 1;
+
+  char *buf = malloc(MAX_STAT_READ_SIZE);
+  ssize_t bytes_read;
+  if ((bytes_read = read(fd, buf, MAX_STAT_READ_SIZE)) == -1) {
+    printErr("read failed: errno: %d", errno);
+    if (close(fd) == -1) {
+      printErr("close failed: errno: %d", errno);
+    }
+    if (buf != NULL) {
+      free(buf);
+    }
+    return NULL;
+  }
+
+  // -1 to overwrite the trailing '\n'
+  buf[bytes_read - 1] = '\0';
+  if (close(fd) == -1) {
+    printErr("close failed: errno: %d", errno);
+    free(buf);
+    return NULL;
+  }
+  return buf;
+}
+
+static int printStats(const CgroupLocs *cg_locs, pid_t pid) {
+
+  char *buf;
+  char *memory_pid_dir = getPidDir(cg_locs -> memory, pid);
+  if ((buf = readFile(memory_pid_dir, "memory.max_usage_in_bytes")) == NULL) {
+    printErr("readFile failed: errno: %d", errno);
+    free(memory_pid_dir);
+    return -1;
+  }
+  printf("Stats\n");
+  printf("`````\n");
+  printf("Memory usage in bytes: %s\n", buf);
+  free(buf);
+  free(memory_pid_dir);
+
+  char *cpuacct_pid_dir = getPidDir(cg_locs -> cpuacct, pid);
+  if ((buf = readFile(cpuacct_pid_dir, "cpuacct.usage")) == NULL) {
+    printErr("readFile failed: errno: %d", errno);
+    free(cpuacct_pid_dir);
+    return -1;
+  }
+  printf("CPU time in nanoseconds: %s\n", buf);
+  free(buf);
+  free(cpuacct_pid_dir);
+
+  char *pids_pid_dir= getPidDir(cg_locs -> pids, pid);
+  if ((buf = readFile(pids_pid_dir, "pids.current")) == NULL) {
+    printErr("readFile failed: errno: %d", errno);
+    free(pids_pid_dir);
+    return -1;
+  }
+  printf("Current number of tasks: %s\n\n", buf);
+  free(buf);
+  free(pids_pid_dir);
+  return 0;
+}
+
+// -------------------- Helper Functions - End ----------------------------
+
+int terminatePid(const CgroupLocs *cg_locs, pid_t pid) {
   int ret = 0;
-  if (!(tp -> terminated)) {
-    // TODO: handle corner case of killing init in PID NS
-    if (kill(tp -> pid, SIGKILL) == -1) {
-      printErr("kill failed: errno: %d", errno);
-      ret = -1;
-    }
 
-    // wait until 'sandboxExec' confirms the process has terminated
-    while (tp -> terminated == 0);
-
-    #ifdef SB_VERBOSE
-    printf("Killed %d\n", tp -> pid);
-    #endif
-  }
-
-  int i;
-  for (i = 0; i < (tp -> threads_len); i++) {
-    if ((tp -> skip == NULL) || pthread_equal((tp -> threads)[i], *(tp -> skip)) == 0) {
-      pthread_cancel((tp -> threads)[i]);
-      #ifdef SB_VERBOSE
-      printf("Killed thread: %d\n", i);
-      #endif
-      pthread_join((tp -> threads)[i], NULL);
-    }
-  }
-
-  if (removePidDirs(tp -> cg_locs, tp -> pid) == -1) {
-    printErr("removePidDirs failed: errno: %d", errno);
+  #ifdef SB_PRINT_STATS
+  if (printStats(cg_locs, pid) == -1) {
+    printErr("printStats failed");
     ret = -1;
   }
-  tp -> done = 1;
-  return 0;
+  #endif
+
+  if (kill(pid, SIGKILL) == -1) {
+    printErr("kill failed: errno: %d", errno);
+    ret = -1;
+  }
+  return ret;
+}
+
+void terminateThreads(pthread_t *threads, int num_threads) {
+  int i;
+  for (i = 0; i < num_threads; i++) {
+    if (pthread_cancel(threads[i]) == -1) {
+      printErr("pthread_cancel failed: errno: %d", errno);
+    }
+  }
+  for (i = 0; i < num_threads; i++) {
+    pthread_join(threads[i], NULL);
+  }
 }

--- a/src/server/contest/sandbox/terminate.h
+++ b/src/server/contest/sandbox/terminate.h
@@ -6,20 +6,12 @@
 
 #include "resource_limits.h"
 
-typedef struct TerminatePayload {
-  pthread_t *threads;
-  // threads[i] that is equal to *skip is not cancelled; all others are
-  pthread_t *skip;
-  int threads_len;
-  int terminated; // 1 if the sandboxed executable is terminated
-  int done; // becomes 1 (from 0) when the 'terminate' completes once
-  int once; // 1 if 'terminate' is called atleast once else 0
-  pid_t pid;
-  const CgroupLocs *cg_locs;
-} TerminatePayload;
+char *getPidDir(const char *cg, pid_t pid);
 
 int removePidDirs(const CgroupLocs *cg_locs, pid_t pid);
 
-int terminate(TerminatePayload *tp);
+int terminatePid(const CgroupLocs *cg_locs, pid_t pid);
+
+void terminateThreads(pthread_t *threads, int num_threads);
 
 #endif


### PR DESCRIPTION
Earlier, when some resource limiting thread(rlt) found the sandboxed
executable to be exceeding a certain resource usage limit, it was terminated
by the same rlt. Other rlts were also terminated by the same rltd.

However, now, when an rlt finds some limit to be exceeded, it terminates the
sandboxed executable as previously, but other rlts are not terminated by this rlt. All rlts
irrespective of the situation, are terminated by the main thread that
performs the wait.