### PR TITLE
bank: Fix IsADirectoryError when deleting problems

### DIFF
--- a/src/server/bank/models.py
+++ b/src/server/bank/models.py
@@ -54,5 +54,7 @@ def delete_testcases_folder(sender, instance, **kwargs):
 @receiver(pre_delete, sender=Problem)
 def delete_problem_file(sender, instance, **kwargs):
     problem = Problem.objects.get(problem_id=instance.problem_id)
+    if not problem.problem_file:
+        return
     problem_file = Path(str(problem.problem_file))
     problem_file.unlink()


### PR DESCRIPTION
When no problem file was uploaded, the code defaulted to current
directory as Path for problem file. Now, the function returns when the
problem.problem_file is empty.

Fixes #65